### PR TITLE
Use git tags for version instead of hardcoded value

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,23 @@ jobs:
       run: |
         echo "Running comprehensive tests for release..."
         go test -v -race ./...
-    
+
+    - name: Build release binaries
+      run: |
+        TAG_NAME=${GITHUB_REF#refs/tags/}
+        mkdir -p dist
+
+        # Build for multiple platforms
+        GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-linux-amd64 ./cmd/skimatik
+        GOOS=linux GOARCH=arm64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-linux-arm64 ./cmd/skimatik
+        GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-darwin-amd64 ./cmd/skimatik
+        GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-darwin-arm64 ./cmd/skimatik
+        GOOS=windows GOARCH=amd64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-windows-amd64.exe ./cmd/skimatik
+
+        # Create checksums
+        cd dist
+        sha256sum * > checksums.txt
+
     - name: Generate changelog
       id: changelog
       run: |
@@ -71,7 +87,8 @@ jobs:
         gh release create ${{ steps.changelog.outputs.tag_name }} \
           --title "Release ${{ steps.changelog.outputs.tag_name }}" \
           --notes-file changelog.md \
-          $(if [[ "${{ steps.changelog.outputs.tag_name }}" == *"-"* ]]; then echo "--prerelease"; fi)
+          $(if [[ "${{ steps.changelog.outputs.tag_name }}" == *"-"* ]]; then echo "--prerelease"; fi) \
+          dist/*
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GOLINT=golangci-lint
 BINARY_NAME=skimatik
 BINARY_PATH=./bin/$(BINARY_NAME)
 MAIN_PATH=./cmd/skimatik
+VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 DOCKER_COMPOSE=docker-compose -f build/docker-compose.yml
 
 # Test parameters
@@ -24,9 +25,9 @@ default: help
 # Build the binary
 .PHONY: build
 build:
-	@echo "Building $(BINARY_NAME)..."
+	@echo "Building $(BINARY_NAME) version $(VERSION)..."
 	@mkdir -p bin
-	$(GOBUILD) -o $(BINARY_PATH) $(MAIN_PATH)
+	$(GOBUILD) -ldflags="-X main.version=$(VERSION)" -o $(BINARY_PATH) $(MAIN_PATH)
 	@echo "✅ Binary built: $(BINARY_PATH)"
 
 # Run unit tests only (no database required)

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -14,7 +14,8 @@ RUN go mod download
 COPY . .
 
 # Build the binary
-RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o skimatik ./cmd/skimatik
+ARG VERSION=dev
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags="-X main.version=${VERSION}" -o skimatik ./cmd/skimatik
 
 # Final stage
 FROM alpine:latest

--- a/cmd/skimatik/main.go
+++ b/cmd/skimatik/main.go
@@ -10,12 +10,14 @@ import (
 	"github.com/nhalm/skimatik/internal/generator"
 )
 
+var version = "dev"
+
 func main() {
 	var (
-		config  = flag.String("config", "skimatik.yaml", "Path to YAML configuration file")
-		verbose = flag.Bool("verbose", false, "Enable verbose logging output")
-		help    = flag.Bool("help", false, "Show detailed help and examples")
-		version = flag.Bool("version", false, "Show version information")
+		config     = flag.String("config", "skimatik.yaml", "Path to YAML configuration file")
+		verbose    = flag.Bool("verbose", false, "Enable verbose logging output")
+		help       = flag.Bool("help", false, "Show detailed help and examples")
+		showVersion = flag.Bool("version", false, "Show version information")
 	)
 
 	// Custom usage function with better formatting
@@ -136,8 +138,8 @@ MORE INFO:
 		os.Exit(0)
 	}
 
-	if *version {
-		fmt.Println("skimatik version 2.0.0")
+	if *showVersion {
+		fmt.Printf("skimatik version %s\n", version)
 		fmt.Println("Database-first code generator for PostgreSQL")
 		fmt.Println("https://github.com/nhalm/skimatik")
 		os.Exit(0)


### PR DESCRIPTION
## Summary
Replaces hardcoded version "2.0.0" with dynamic version injection from git tags.

## Changes
- Added package-level `var version = "dev"` in cmd/skimatik/main.go
- Updated Makefile to inject version via ldflags using `git describe --tags`
- Updated Dockerfile to support VERSION build arg
- Updated release workflow to:
  - Build multi-platform binaries (linux/darwin/windows, amd64/arm64)
  - Inject proper version into each binary
  - Generate SHA256 checksums
  - Attach all binaries to GitHub release

## Testing
```bash
# Build with make (uses git tags)
make build
./bin/skimatik --version
# Output: skimatik version v0.3.0-dirty

# Run without build (defaults to dev)
go run cmd/skimatik/main.go --version
# Output: skimatik version dev
```

## Breaking Changes
None - this is internal to the build process

Resolves #48