### PR TITLE
Add GoReleaser for automated multi-platform releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,65 +30,13 @@ jobs:
       uses: actions/setup-go@v6
       with:
         go-version: '1.24'
-    
-    - name: Run full test suite
-      run: |
-        echo "Running comprehensive tests for release..."
-        go test -v -race ./...
 
-    - name: Build release binaries
-      run: |
-        TAG_NAME=${GITHUB_REF#refs/tags/}
-        mkdir -p dist
-
-        # Build for multiple platforms
-        GOOS=linux GOARCH=amd64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-linux-amd64 ./cmd/skimatik
-        GOOS=linux GOARCH=arm64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-linux-arm64 ./cmd/skimatik
-        GOOS=darwin GOARCH=amd64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-darwin-amd64 ./cmd/skimatik
-        GOOS=darwin GOARCH=arm64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-darwin-arm64 ./cmd/skimatik
-        GOOS=windows GOARCH=amd64 go build -ldflags="-X main.version=$TAG_NAME" -o dist/skimatik-windows-amd64.exe ./cmd/skimatik
-
-        # Create checksums
-        cd dist
-        sha256sum * > checksums.txt
-
-    - name: Generate changelog
-      id: changelog
-      run: |
-        # Get the tag name
-        TAG_NAME=${GITHUB_REF#refs/tags/}
-        echo "tag_name=$TAG_NAME" >> $GITHUB_OUTPUT
-        
-        # Generate changelog from git commits
-        PREVIOUS_TAG=$(git describe --tags --abbrev=0 HEAD~1 2>/dev/null || echo "")
-        if [ -z "$PREVIOUS_TAG" ]; then
-          CHANGELOG=$(git log --pretty=format:"- %s" --reverse)
-        else
-          CHANGELOG=$(git log --pretty=format:"- %s" --reverse $PREVIOUS_TAG..HEAD)
-        fi
-        
-        # Save changelog to file and output
-        {
-          echo "## What's Changed"
-          echo "$CHANGELOG"
-          echo ""
-          echo "**Full Changelog**: https://github.com/${{ github.repository }}/commits/$TAG_NAME"
-        } > changelog.md
-        
-        # Save to output for use in release
-        {
-          echo "changelog<<EOF"
-          cat changelog.md
-          echo "EOF"
-        } >> $GITHUB_OUTPUT
-    
-    - name: Create Release
-      run: |
-        gh release create ${{ steps.changelog.outputs.tag_name }} \
-          --title "Release ${{ steps.changelog.outputs.tag_name }}" \
-          --notes-file changelog.md \
-          $(if [[ "${{ steps.changelog.outputs.tag_name }}" == *"-"* ]]; then echo "--prerelease"; fi) \
-          dist/*
+    - name: Run GoReleaser
+      uses: goreleaser/goreleaser-action@v6
+      with:
+        distribution: goreleaser
+        version: latest
+        args: release --clean
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,61 @@
+version: 2
+
+before:
+  hooks:
+    - go mod tidy
+    - go test ./...
+
+builds:
+  - id: skimatik
+    main: ./cmd/skimatik
+    binary: skimatik
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.Commit}}
+      - -X main.date={{.Date}}
+
+archives:
+  - format: tar.gz
+    name_template: >-
+      {{ .ProjectName }}_
+      {{- .Version }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    files:
+      - LICENSE
+      - README.md
+
+checksum:
+  name_template: 'checksums.txt'
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+      - '^chore:'
+      - '^ci:'
+
+release:
+  github:
+    owner: nhalm
+    name: skimatik
+  draft: false
+  prerelease: auto

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,8 @@ BINARY_NAME=skimatik
 BINARY_PATH=./bin/$(BINARY_NAME)
 MAIN_PATH=./cmd/skimatik
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
+COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 DOCKER_COMPOSE=docker-compose -f build/docker-compose.yml
 
 # Test parameters
@@ -27,7 +29,7 @@ default: help
 build:
 	@echo "Building $(BINARY_NAME) version $(VERSION)..."
 	@mkdir -p bin
-	$(GOBUILD) -ldflags="-X main.version=$(VERSION)" -o $(BINARY_PATH) $(MAIN_PATH)
+	$(GOBUILD) -ldflags="-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o $(BINARY_PATH) $(MAIN_PATH)
 	@echo "✅ Binary built: $(BINARY_PATH)"
 
 # Run unit tests only (no database required)

--- a/cmd/skimatik/main.go
+++ b/cmd/skimatik/main.go
@@ -6,11 +6,39 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime/debug"
 
 	"github.com/nhalm/skimatik/internal/generator"
 )
 
-var version = "dev"
+var (
+	version = "dev"
+	commit  = "none"
+	date    = "unknown"
+)
+
+func getVersion() string {
+	if version != "dev" {
+		return version
+	}
+
+	if info, ok := debug.ReadBuildInfo(); ok && info.Main.Version != "(devel)" && info.Main.Version != "" {
+		return info.Main.Version
+	}
+
+	return "dev"
+}
+
+func getFullVersion() string {
+	v := getVersion()
+	if commit != "none" {
+		v = fmt.Sprintf("%s (commit: %s)", v, commit[:7])
+	}
+	if date != "unknown" {
+		v = fmt.Sprintf("%s built at %s", v, date)
+	}
+	return v
+}
 
 func main() {
 	var (
@@ -139,7 +167,7 @@ MORE INFO:
 	}
 
 	if *showVersion {
-		fmt.Printf("skimatik version %s\n", version)
+		fmt.Printf("skimatik %s\n", getFullVersion())
 		fmt.Println("Database-first code generator for PostgreSQL")
 		fmt.Println("https://github.com/nhalm/skimatik")
 		os.Exit(0)


### PR DESCRIPTION
## Summary
Replaces manual build scripts with GoReleaser - the industry-standard Go release automation tool used by kubectl, helm, terraform, and many others.

## Changes

### GoReleaser Configuration
- Added  with builds for:
  - Linux (amd64, arm64)
  - macOS/Darwin (amd64, arm64) 
  - Windows (amd64)
- Automatic archive generation (tar.gz for unix, zip for windows)
- SHA256 checksum generation
- Changelog generation from git commits

### Enhanced Version Information
- Added `commit` and `date` variables alongside `version`
- Enhanced `--version` output to show:
  - Version from git tags
  - Commit hash (first 7 chars)
  - Build timestamp
- Falls back to `runtime/debug.ReadBuildInfo()` for `go install` scenarios

### Simplified Release Workflow
- **Before**: ~50 lines of bash for manual builds
- **After**: Single goreleaser-action (5 lines)
- Automatic prerelease detection for tags with hyphens
- All binaries automatically attached to GitHub release

### Updated Makefile
- Added COMMIT and DATE variables
- Updated ldflags to inject version, commit, and date
- Matches GoReleaser's ldflags format

## Testing
```bash
make build
./bin/skimatik --version
# Output: skimatik v0.3.1-dirty (commit: d5dee68) built at 2025-10-21T19:39:01Z
```

## Benefits
- ✅ Industry-standard tool with proven reliability
- ✅ Consistent builds across all platforms
- ✅ Better version information in binaries
- ✅ Simpler workflow maintenance
- ✅ Automatic archive and checksum generation
- ✅ Built-in changelog generation

Resolves #50