### PR TITLE
fix: enable CGO for pg_query_go in release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,7 +10,7 @@ builds:
     main: ./cmd/skimatik
     binary: skimatik
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
     goos:
       - linux
       - darwin


### PR DESCRIPTION
The pg_query_go library requires CGO to access PostgreSQL's C parser. Enables CGO_ENABLED=1 in goreleaser config to fix release build failures.

Closes #61