### PR TITLE
feat: cursor_columns pagination for custom queries

### DIFF
--- a/internal/generator/codegen.go
+++ b/internal/generator/codegen.go
@@ -149,6 +149,7 @@ func (cg *CodeGenerator) combineImports(lists ...[]string) []string {
 func (cg *CodeGenerator) getQueryImports(queries []Query) []string {
 	imports := make(map[string]bool)
 
+	hasCursorColumns := false
 	for _, query := range queries {
 		// Get imports for result columns
 		queryImports := cg.typeMapper.GetRequiredImports(query.Columns)
@@ -161,6 +162,16 @@ func (cg *CodeGenerator) getQueryImports(queries []Query) []string {
 		for _, imp := range paramImports {
 			imports[imp] = true
 		}
+
+		// Check if query uses cursor_columns
+		if len(query.CursorColumns) > 0 {
+			hasCursorColumns = true
+		}
+	}
+
+	// Add reflect package if any query uses cursor_columns
+	if hasCursorColumns {
+		imports["reflect"] = true
 	}
 
 	// Convert map to slice
@@ -970,8 +981,10 @@ func (cg *CodeGenerator) prepareQueryTemplateData(query Query) (map[string]inter
 	}
 
 	paramArgStr := ""
+	paramArgsOnly := ""
 	if len(paramArgs) > 0 {
-		paramArgStr = ", " + strings.Join(paramArgs, ", ")
+		paramArgsOnly = strings.Join(paramArgs, ", ")
+		paramArgStr = ", " + paramArgsOnly
 	}
 
 	return map[string]interface{}{
@@ -982,6 +995,7 @@ func (cg *CodeGenerator) prepareQueryTemplateData(query Query) (map[string]inter
 		"ResultType":            resultType,
 		"ParameterDeclarations": paramDeclStr,
 		"ParameterArgs":         paramArgStr,
+		"ParameterArgsOnly":     paramArgsOnly,
 		"ScanArgs":              strings.Join(scanArgs, ", "),
 		"CursorColumns":         query.CursorColumns,
 	}, nil

--- a/internal/generator/templates/queries/many_query.tmpl
+++ b/internal/generator/templates/queries/many_query.tmpl
@@ -68,9 +68,9 @@ func (r *{{.RepositoryName}}) {{.FunctionName}}Paginated(ctx context.Context{{.P
 			"SELECT * FROM (%s) AS subquery WHERE %s > $%d ORDER BY %s ASC LIMIT $%d",
 			baseQuery,
 			orderBy,
-			{{if .ParameterArgs}}len([]interface{}{ {{.ParameterArgs}} })+1{{else}}1{{end}},
+			{{if .ParameterArgsOnly}}len([]interface{}{ {{.ParameterArgsOnly}} })+1{{else}}1{{end}},
 			orderBy,
-			{{if .ParameterArgs}}len([]interface{}{ {{.ParameterArgs}} })+2{{else}}2{{end}},
+			{{if .ParameterArgsOnly}}len([]interface{}{ {{.ParameterArgsOnly}} })+2{{else}}2{{end}},
 		)
 	} else {
 		// No cursor, just add ORDER BY and LIMIT
@@ -78,14 +78,14 @@ func (r *{{.RepositoryName}}) {{.FunctionName}}Paginated(ctx context.Context{{.P
 			"SELECT * FROM (%s) AS subquery ORDER BY %s ASC LIMIT $%d",
 			baseQuery,
 			orderBy,
-			{{if .ParameterArgs}}len([]interface{}{ {{.ParameterArgs}} })+1{{else}}1{{end}},
+			{{if .ParameterArgsOnly}}len([]interface{}{ {{.ParameterArgsOnly}} })+1{{else}}1{{end}},
 		)
 	}
 
 	// Build parameter list
 	var args []interface{}
-	{{if .ParameterArgs}}
-	args = append(args, {{.ParameterArgs}})
+	{{if .ParameterArgsOnly}}
+	args = append(args, {{.ParameterArgsOnly}})
 	{{end}}
 	if cursorValue != nil {
 		args = append(args, cursorValue)
@@ -124,17 +124,32 @@ func (r *{{.RepositoryName}}) {{.FunctionName}}Paginated(ctx context.Context{{.P
 	var nextCursor string
 	if hasMore && len(items) > 0 {
 		lastItem := items[len(items)-1]
-		// Extract the orderBy column value and encode it
-		var cursorVal string
-		switch orderBy {
-		{{range .CursorColumns}}
-		case "{{.}}":
-			// Use reflection or type assertion to get field value
-			// For simplicity, encoding the whole struct for now
-			cursorVal = fmt.Sprintf("%v", lastItem)
-		{{end}}
+
+		// Extract the orderBy column value using reflection
+		v := reflect.ValueOf(lastItem)
+		fieldName := toCamelCase(orderBy)
+
+		// Handle both struct and pointer to struct
+		if v.Kind() == reflect.Ptr {
+			v = v.Elem()
 		}
-		nextCursor = base64.URLEncoding.EncodeToString([]byte(cursorVal))
+
+		if v.Kind() != reflect.Struct {
+			return nil, fmt.Errorf("cannot extract cursor from non-struct type")
+		}
+
+		field := v.FieldByName(fieldName)
+		if !field.IsValid() {
+			return nil, fmt.Errorf("field %q not found in result type for cursor", fieldName)
+		}
+
+		// Format the field value for cursor encoding
+		cursorValue := formatCursorValue(field.Interface())
+		cursorData, err := encodeJSONCursor(orderBy, cursorValue)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode cursor: %w", err)
+		}
+		nextCursor = cursorData
 	}
 
 	return &PaginationResult[{{.ResultType}}]{


### PR DESCRIPTION
Implements cursor-based pagination support for custom queries using the `cursor_columns` annotation.

## Overview
Adds `cursor_columns` annotation support for custom queries defined in .sql files, enabling efficient cursor-based pagination with runtime sort selection.

## Key Features
- `cursor_columns` annotation in query files specifies columns for pagination
- Generates two functions: paginated version with `PaginationParams` and standard version
- Runtime sort order selection via `orderBy` parameter with allowlist validation
- Bidirectional navigation with NextCursor/BeforeCursor
- Comprehensive test coverage and documentation

## Commits
- feat: implement cursor_columns pagination for custom queries
- docs: improve cursor_columns pagination documentation  
- fix: apply go fmt formatting corrections
- fix: remove duplicate parseCursorColumnsAnnotation method
- fix: remove unused generateInlinePaginationTypes function
- fix: use NextCursor instead of Cursor in pagination template
- test: add comprehensive coverage for cursor_columns pagination
- fix: resolve cursor_columns bugs from code review

Fixes #77