### PR TITLE
fix: use correct ID type in *WithRetry method parameters

### DIFF
--- a/internal/generator/templates/repository/retry_methods.tmpl
+++ b/internal/generator/templates/repository/retry_methods.tmpl
@@ -6,14 +6,14 @@ func (r *{{.RepositoryName}}) CreateWithRetry(ctx context.Context, params Create
 }
 
 // GetWithRetry retrieves a {{.StructName}} by ID with retry logic
-func (r *{{.RepositoryName}}) GetWithRetry(ctx context.Context, id uuid.UUID) (*{{.StructName}}, error) {
+func (r *{{.RepositoryName}}) GetWithRetry(ctx context.Context, id {{.IDType}}) (*{{.StructName}}, error) {
 	return RetryOperation(ctx, DefaultRetryConfig, "get", func(ctx context.Context) (*{{.StructName}}, error) {
 		return r.Get(ctx, id)
 	})
 }
 
 // UpdateWithRetry updates an existing {{.StructName}} with retry logic
-func (r *{{.RepositoryName}}) UpdateWithRetry(ctx context.Context, id uuid.UUID, params Update{{.StructName}}Params) (*{{.StructName}}, error) {
+func (r *{{.RepositoryName}}) UpdateWithRetry(ctx context.Context, id {{.IDType}}, params Update{{.StructName}}Params) (*{{.StructName}}, error) {
 	return RetryOperation(ctx, DefaultRetryConfig, "update", func(ctx context.Context) (*{{.StructName}}, error) {
 		return r.Update(ctx, id, params)
 	})


### PR DESCRIPTION
## Summary
- Updates `GetWithRetry` and `UpdateWithRetry` to use `{{.IDType}}` template variable instead of hardcoded `uuid.UUID`
- Ensures retry wrapper methods match the parameter types of their base methods (Get, Update)
- Fixes build errors when using TEXT primary keys

Fixes #86