### PR TITLE
refactor: simplify Makefile test targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,15 @@ jobs:
     strategy:
       matrix:
         go-version: [ '1.24', '1.25' ]
-    
+
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: ${{ matrix.go-version }}
-    
+
     - name: Cache Go modules
       uses: actions/cache@v4
       with:
@@ -31,13 +31,13 @@ jobs:
         key: ${{ runner.os }}-go-${{ matrix.go-version }}-${{ hashFiles('**/go.sum') }}-v2
         restore-keys: |
           ${{ runner.os }}-go-${{ matrix.go-version }}-v2-
-    
+
     - name: Download dependencies
       run: go mod download
-    
+
     - name: Verify dependencies
       run: go mod verify
-    
+
     - name: Run tests
       run: go test -v -race -parallel=1 ./...
 
@@ -46,12 +46,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: '1.24'
-    
+
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
@@ -63,15 +63,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: '1.24'
-    
+
     - name: Install Gosec
       run: go install github.com/securego/gosec/v2/cmd/gosec@latest
-    
+
     - name: Run Gosec Security Scanner
       run: gosec -exclude=G115 ./...
       continue-on-error: true
@@ -82,12 +82,12 @@ jobs:
     needs: [test, lint]
     steps:
     - uses: actions/checkout@v6
-    
+
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
         go-version: '1.24'
-    
+
     - name: Build
       run: go build -v ./...
 
@@ -121,7 +121,7 @@ jobs:
       run: docker compose -f build/docker-compose.yml down -v
 
   example-app-integration:
-    name: Example App Comprehensive Integration Test
+    name: Example App Integration Test
     runs-on: ubuntu-latest
     needs: [test, lint]
 
@@ -146,14 +146,9 @@ jobs:
     - name: Download dependencies
       run: go mod download
 
-    - name: Set up example app database
-      run: cd example-app && make setup
-
-    - name: Run comprehensive example app integration test
-      run: make example-app-test
+    - name: Run example app tests
+      run: make test-example-app
 
     - name: Clean up
       if: always()
       run: cd example-app && make clean
-
- 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,35 +39,17 @@ type CustomUserRepo struct {
 }
 ```
 
-## Using the Makefile (IMPORTANT - Use This!)
-
-**Always use the Makefile for development tasks.** It ensures correct flags, database setup, and test execution.
-
-### Essential Targets
+## Using the Makefile
 
 ```bash
-make build              # Build the skimatik binary (output: bin/skimatik)
-make test               # Run unit tests (no database needed)
-make integration-test   # Run integration tests (auto-starts database)
-make example-app-test   # End-to-end validation (build + generate + test)
-make lint               # Run golangci-lint and go fmt
-make dev-setup          # Start PostgreSQL database for development
-make clean              # Clean build artifacts and stop services
+make build            # Build the skimatik binary
+make test-unit        # Run unit tests (no database)
+make test-integration # Run integration tests (auto-starts database)
+make test-example-app # Run example-app tests (auto-setup)
+make test-all         # Run all tests
+make lint             # Run golangci-lint and go fmt
+make clean            # Clean build artifacts and stop services
 ```
-
-### Quick Development Workflow
-
-```bash
-make build                 # Build after code changes
-make test                  # Run unit tests
-make integration-test      # Run integration tests (auto-starts DB)
-make example-app-test      # Full end-to-end validation
-```
-
-**Database for tests:**
-- `integration-test` automatically starts PostgreSQL via Docker Compose
-- Connection: `postgres://skimatik:skimatik_test_password@localhost:5432/skimatik_test`
-- Uses `build/docker-compose.yml`
 
 ## example-app
 
@@ -91,7 +73,7 @@ cd example-app
 
 make setup         # Start database and run migrations
 make generate      # Run skimatik to generate repository code
-make test          # Full integration test (builds, starts app, tests endpoints)
+make test          # Run tests (auto-setup + generate + test)
 make run           # Start the API server
 make clean         # Clean generated code and stop database
 
@@ -105,76 +87,25 @@ make migrate-create NAME=foo # Create new migration
 ### example-app Test Flow
 
 When you run `make test` in example-app:
-1. Builds the application (validates generated code compiles)
-2. Starts the API server in background
-3. Tests all endpoints with curl:
-   - Health check
-   - User CRUD (generated repositories)
-   - Post CRUD (custom repositories)
-   - Posts with stats (generated query integration)
-   - Featured posts (custom business logic)
-   - User search (query-based functionality)
-4. Validates API returns real data (not stubs)
-5. Stops the server
-
-**This is the ultimate validation** that code generation works correctly.
+1. Auto-starts database if not running
+2. Runs migrations
+3. Generates code with skimatik
+4. Builds the application
+5. Starts the API server
+6. Tests all endpoints with curl
+7. Stops the server
 
 ## Documentation & Wiki
 
-### Documentation Structure
-
-All documentation lives in `/docs/` as Markdown files:
-
-```
-docs/
-├── home.md                      # Wiki homepage
-├── quick-start.md               # Installation and basic usage
-├── examples.md                  # Real-world usage examples
-├── configuration-reference.md   # Complete config options
-├── database-migrations.md       # Schema management with golang-migrate
-├── embedding-patterns.md        # Repository composition patterns
-├── shared-utilities.md          # Reusable utilities reference
-├── error-handling.md            # Error handling patterns
-├── troubleshooting.md           # Common issues and fixes
-├── tutorial-blog-app.md         # Blog app walkthrough
-├── type-mapping.md              # PostgreSQL to Go type mapping
-├── _Sidebar.md                  # Wiki navigation sidebar
-└── _Footer.md                   # Wiki footer
-```
-
-### Wiki Sync Workflow
-
-**How it works**: `.github/workflows/sync-wiki.yml` automatically syncs `docs/` to GitHub Wiki.
-
-**Triggers**:
-- Push to `main` branch with changes in `docs/**`
-- Manual trigger via workflow_dispatch
-
-**What it does**:
-1. Checks out main repository
-2. Checks out wiki repository
-3. Deletes existing wiki .md files
-4. Copies all files from `docs/` to wiki
-5. Commits and pushes to wiki
-
-**To update documentation**:
-1. Edit files in `/docs/`
-2. Commit and push to `main`
-3. Workflow auto-syncs to wiki
-4. Changes appear at `https://github.com/nhalm/skimatik/wiki`
-
-**Important**: Never edit wiki directly through GitHub UI - changes will be overwritten. Always edit in `/docs/` directory.
+All documentation lives in `/docs/` as Markdown files. Push to `main` and the wiki auto-syncs.
 
 ## Key Files
 
 - `go.mod` - Uses wasilibs/go-pgquery (WASM) + pganalyze types for SQL parsing
 - `.goreleaser.yml` - Release config with `CGO_ENABLED=0` (required for wasilibs)
 - `skimatik.yaml` - User config (database connection, tables, output paths)
-- `Makefile` - Development workflow automation (USE THIS!)
-- `.github/workflows/sync-wiki.yml` - Auto-sync docs to wiki
+- `Makefile` - Development workflow automation
 - `.github/workflows/ci.yml` - CI pipeline
-- `.github/workflows/release.yml` - Release automation
-- `.github/workflows/context7-sync.yml` - Sync to Context7 on releases
 
 ## Database Requirements
 
@@ -182,30 +113,13 @@ docs/
 - Tables must have UUID primary keys for pagination
 - Uses `information_schema` for metadata
 
-## Code Generation Flow
-
-1. Connect to database
-2. Read table schemas from `information_schema`
-3. Parse custom SQL files (if any) using pg_query
-4. Extract parameter types and query structure
-5. Generate Go code via templates
-6. Write to output directory
-
 ## Testing
 
-**Unit tests** (no database):
 ```bash
-make test
-```
-
-**Integration tests** (auto-starts database):
-```bash
-make integration-test
-```
-
-**End-to-end validation** (build + generate + test example-app):
-```bash
-make example-app-test
+make test-unit        # Unit tests (no database)
+make test-integration # Integration tests (auto-starts database)
+make test-example-app # Example app tests (auto-setup)
+make test-all         # All tests
 ```
 
 ## Common Development Tasks
@@ -214,7 +128,7 @@ make example-app-test
 
 1. Modify templates in `internal/generator/template.go`
 2. Update `codegen.go` to pass new data to templates
-3. Run `make example-app-test` to validate
+3. Run `make test-example-app` to validate
 4. Update relevant docs in `/docs/`
 
 ### Modifying SQL Parsing
@@ -222,36 +136,21 @@ make example-app-test
 1. Edit `internal/generator/sql_parser.go`
 2. Uses `pg_query.Parse()` from wasilibs
 3. Returns `*pg_query_go.ParseResult` (types from pganalyze)
-4. Run `make test` to validate parsing logic
-
-### Updating Documentation
-
-1. Edit files in `/docs/` directory
-2. Test locally by reading the .md files
-3. Commit and push to `main`
-4. Wiki auto-syncs via workflow
+4. Run `make test-unit` to validate parsing logic
 
 ### Testing Changes End-to-End
 
 1. Make code changes
-2. Run `make build` to build new binary
-3. Run `cd example-app && make clean && make generate` to regenerate code
-4. Run `cd example-app && make test` to validate
-5. Or use `make example-app-test` from root to do it all
+2. Run `make test-example-app` (builds, generates, tests)
 
 ### Creating Releases
 
 1. Tag with semantic version: `git tag v0.x.x`
 2. Push tag: `git push origin v0.x.x`
-3. Release workflow automatically:
-   - Runs tests
-   - Builds binaries for all platforms
-   - Creates GitHub release
-   - Triggers Context7 doc sync
+3. Release workflow automatically builds and publishes
 
 ## Build Notes
 
 - CGO disabled in goreleaser for cross-platform builds
 - wasilibs/go-pgquery provides PostgreSQL parser via WebAssembly
-- ~4-5x slower than CGO version, acceptable for CLI tool
 - Generated code only depends on pgx and pgxkit

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,11 @@
 # Makefile for skimatik project
 
-# Go parameters
 GOCMD=go
 GOBUILD=$(GOCMD) build
 GOTEST=$(GOCMD) test
 GOMOD=$(GOCMD) mod
 GOLINT=golangci-lint
 
-# Project parameters
 BINARY_NAME=skimatik
 BINARY_PATH=./bin/$(BINARY_NAME)
 MAIN_PATH=./cmd/skimatik
@@ -16,15 +14,11 @@ COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
 DATE := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 DOCKER_COMPOSE=docker-compose -f build/docker-compose.yml
 
-# Test parameters
 TEST_DB_URL=postgres://skimatik:skimatik_test_password@localhost:5432/skimatik_test?sslmode=disable
-TEST_TIMEOUT=30s
 
-# Default target - show help
 .PHONY: default
 default: help
 
-# Build the binary
 .PHONY: build
 build:
 	@echo "Building $(BINARY_NAME) version $(VERSION)..."
@@ -32,99 +26,65 @@ build:
 	$(GOBUILD) -ldflags="-s -w -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)" -o $(BINARY_PATH) $(MAIN_PATH)
 	@echo "✅ Binary built: $(BINARY_PATH)"
 
-# Run unit tests only (no database required)
-.PHONY: test
-test:
+.PHONY: test-unit
+test-unit:
 	@echo "Running unit tests..."
 	$(GOMOD) tidy
-	$(GOTEST) -v -timeout $(TEST_TIMEOUT) -short ./...
+	$(GOTEST) -v -timeout 30s -short ./...
 	@echo "✅ Unit tests completed"
 
-# Run integration tests (requires database)
-.PHONY: integration-test
-integration-test: dev-setup
+.PHONY: test-integration
+test-integration:
+	@echo "Starting database..."
+	@$(DOCKER_COMPOSE) up -d postgres
+	@echo "Waiting for database..."
+	@bash -c 'for i in {1..30}; do if pg_isready -h localhost -p 5432 -U skimatik -d skimatik_test >/dev/null 2>&1; then break; fi; sleep 1; done'
 	@echo "Running integration tests..."
 	$(GOMOD) tidy
-	TEST_DATABASE_URL=$(TEST_DB_URL) $(GOTEST) -v -timeout $(TEST_TIMEOUT) ./...
+	TEST_DATABASE_URL=$(TEST_DB_URL) $(GOTEST) -v -timeout 30s ./...
 	@echo "✅ Integration tests completed"
 
-# Run all tests (unit + integration)
+.PHONY: test-example-app
+test-example-app: build
+	@echo "Running example-app tests..."
+	@cd example-app && $(MAKE) test
+	@echo "✅ Example app tests completed"
+
 .PHONY: test-all
-test-all:
-	@echo "Running all tests..."
-	$(GOMOD) tidy
-	$(GOTEST) -v -timeout $(TEST_TIMEOUT) ./...
+test-all: test-unit test-integration test-example-app
 	@echo "✅ All tests completed"
 
-# Run linter and formatter
 .PHONY: lint
 lint:
-	@echo "Running linter and formatter..."
+	@echo "Running linter..."
 	go fmt ./...
 	$(GOLINT) run ./...
 	@echo "✅ Linting completed"
 
-# Setup development environment
-.PHONY: dev-setup
-dev-setup:
-	@echo "Setting up development environment..."
-	@echo "Starting PostgreSQL database..."
-	$(DOCKER_COMPOSE) up -d postgres
-	@echo "Waiting for database to be ready..."
-	@bash -c 'for i in {1..30}; do if pg_isready -h localhost -p 5432 -U skimatik -d skimatik_test >/dev/null 2>&1; then break; fi; sleep 1; done'
-	@echo "✅ Development environment ready!"
-	@echo "Database URL: $(TEST_DB_URL)"
-
-# Example app integration test (validates end-to-end code generation)
-# Note: Requires database to be set up separately (use with existing CI database or run 'make setup' first locally)
-.PHONY: example-app-test
-example-app-test: build
-	@echo "🧪 Running example-app integration test..."
-	@cd example-app && $(MAKE) generate && $(MAKE) test
-	@echo "✅ Example app integration test completed successfully"
-
-# Clean example app
-.PHONY: example-app-clean
-example-app-clean:
-	@echo "🧹 Cleaning example app..."
-	@cd example-app && $(MAKE) clean
-
-# Clean build artifacts
 .PHONY: clean
 clean:
-	@echo "Cleaning build artifacts..."
+	@echo "Cleaning..."
 	@rm -rf bin/
 	@rm -rf test_output/
 	@rm -rf test-output/
 	@$(DOCKER_COMPOSE) down -v --remove-orphans >/dev/null 2>&1 || true
+	@cd example-app && $(MAKE) clean 2>/dev/null || true
 	@echo "✅ Cleanup completed"
 
-# Show help
 .PHONY: help
 help:
 	@echo ""
-	@echo "🔧 skimatik - Database-first code generator for PostgreSQL"
+	@echo "skimatik - Database-first code generator for PostgreSQL"
 	@echo ""
-	@echo "📋 USAGE:"
-	@echo "  make <target>    Run a specific target"
-	@echo "  make             Show this help message"
+	@echo "Usage: make <target>"
 	@echo ""
-	@echo "🚀 ESSENTIAL TARGETS:"
-	@echo "  build              Build the skimatik binary"
-	@echo "  test               Run unit tests only (no database required)"
-	@echo "  integration-test   Run integration tests (auto-starts database)"
-	@echo "  example-app-test   End-to-end test using example app (validates code generation)"
-	@echo "  test-all           Run all tests (unit + integration)"
-	@echo "  lint               Run linter and code formatter"
-	@echo "  dev-setup          Setup development environment with database"
-	@echo "  clean              Remove build artifacts and stop services"
+	@echo "Targets:"
+	@echo "  build            Build the skimatik binary"
+	@echo "  test-unit        Run unit tests (no database)"
+	@echo "  test-integration Run integration tests (auto-starts database)"
+	@echo "  test-example-app Run example-app tests (auto-setup)"
+	@echo "  test-all         Run all tests"
+	@echo "  lint             Run linter and formatter"
+	@echo "  clean            Remove build artifacts and stop services"
+	@echo "  help             Show this help"
 	@echo ""
-	@echo "💡 QUICK START:"
-	@echo "  make build       # Build the tool"
-	@echo "  make test        # Run unit tests (no database needed)"
-	@echo "  make integration-test  # Run integration tests (auto-starts database)"
-	@echo ""
-	@echo "📚 MORE INFO:"
-	@echo "  ./bin/skimatik --help    # CLI tool usage and options"
-	@echo "  https://github.com/nhalm/skimatik    # Documentation"
-	@echo "" 

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -28,8 +28,8 @@ This guide demonstrates **real usage** of skimatik generated repositories with *
 
 ### 1. Setup Database
 ```bash
-# From project root
-make dev-setup      # Start PostgreSQL with test data
+# From project root - database auto-starts with test commands
+make test-integration   # Auto-starts PostgreSQL
 ```
 
 ### 2. Generate Repositories (if needed)

--- a/docs/tutorial-blog-app.md
+++ b/docs/tutorial-blog-app.md
@@ -190,8 +190,8 @@ func getBoolValue(b *bool) bool {
 The example includes comprehensive integration testing that validates the **complete pipeline**:
 
 ```bash
-# Run complete integration test
-make example-app-test
+# Run complete integration test (from project root)
+make test-example-app
 
 # This validates:
 # 1. Database setup and schema migration

--- a/example-app/Makefile
+++ b/example-app/Makefile
@@ -1,143 +1,98 @@
-# Example Blog Application - Simple Makefile
+# Example Blog Application
 
-# Configuration
 DATABASE_URL = postgres://postgres:password@localhost:15987/blog?sslmode=disable
 MIGRATE_VERSION = v4.17.0
 
-.PHONY: help setup generate test test-ci start-and-test run clean install-migrate migrate-up migrate-down migrate-status migrate-create
+.PHONY: help setup generate test run clean install-migrate migrate-up migrate-down migrate-status migrate-create
 
-help: ## Show available commands
+help:
 	@echo "Example Blog Application"
 	@echo ""
 	@echo "Commands:"
 	@echo "  make setup         - Start database and run migrations"
 	@echo "  make generate      - Generate Go code with skimatik"
-	@echo "  make test          - Run integration tests"
-	@echo "  make test-ci       - Run CI-friendly tests (no background processes)"
-	@echo "  make start-and-test - Start app and test with curl"
+	@echo "  make test          - Run tests (auto-setup)"
 	@echo "  make run           - Run the application"
-	@echo "  make clean         - Clean generated code"
+	@echo "  make clean         - Clean generated code and stop database"
 	@echo ""
 	@echo "Migration commands:"
 	@echo "  make migrate-up     - Apply all pending migrations"
 	@echo "  make migrate-down   - Rollback one migration"
 	@echo "  make migrate-status - Show migration status"
 	@echo "  make migrate-create NAME=<name> - Create a new migration"
-	@echo ""
-	@echo "Quick start: make setup && make generate && make test && make start-and-test"
 
-install-migrate: ## Install golang-migrate if not present
+install-migrate:
 	@if ! command -v migrate >/dev/null 2>&1; then \
-		echo "📦 Installing golang-migrate..."; \
+		echo "Installing golang-migrate..."; \
 		if [ "$$(uname)" = "Darwin" ]; then \
 			brew install golang-migrate; \
 		elif [ "$$(uname)" = "Linux" ]; then \
 			curl -L https://github.com/golang-migrate/migrate/releases/download/$(MIGRATE_VERSION)/migrate.linux-amd64.tar.gz | tar xvz && \
 			sudo mv migrate /usr/local/bin/migrate; \
 		else \
-			echo "⚠️  Please install golang-migrate manually from https://github.com/golang-migrate/migrate/tree/master/cmd/migrate"; \
+			echo "Please install golang-migrate manually"; \
 			exit 1; \
 		fi; \
-	else \
-		echo "✅ golang-migrate already installed"; \
 	fi
 
-setup: install-migrate ## Start database and run migrations
-	@echo "🐘 Setting up database..."
+setup: install-migrate
+	@echo "Setting up database..."
 	@docker run --name blog-db \
 		-e POSTGRES_DB=blog \
 		-e POSTGRES_USER=postgres \
 		-e POSTGRES_PASSWORD=password \
 		-p 15987:5432 \
-		-d postgres:15-alpine || echo "Database already running"
-	@sleep 3
-	@echo "📝 Running migrations..."
-	@migrate -database "$(DATABASE_URL)" -path database/migrations up || (sleep 2 && migrate -database "$(DATABASE_URL)" -path database/migrations up)
-	@echo "✅ Database ready with migrations applied"
+		-d postgres:15-alpine 2>/dev/null || true
+	@echo "Waiting for database..."
+	@bash -c 'for i in {1..30}; do if pg_isready -h localhost -p 15987 -U postgres >/dev/null 2>&1; then break; fi; sleep 1; done'
+	@echo "Running migrations..."
+	@migrate -database "$(DATABASE_URL)" -path database/migrations up 2>/dev/null || sleep 2 && migrate -database "$(DATABASE_URL)" -path database/migrations up
+	@echo "✅ Database ready"
 
-generate: ## Generate Go code with skimatik
-	@echo "⚡ Generating code..."
+generate:
+	@echo "Generating code..."
 	@../bin/skimatik
 	@echo "✅ Code generated"
 
-test: ## Test the application (validates generated code works)
-	@echo "🧪 Testing application..."
-	@echo "🔨 Testing that generated code compiles..."
+test: setup generate
+	@echo "Testing application..."
 	@go build -v ./...
 	@if command -v curl >/dev/null 2>&1; then \
-		echo "🚀 Starting application and testing endpoints..."; \
 		lsof -ti:8080 | xargs kill -9 2>/dev/null || true; \
-		sleep 2; \
+		sleep 1; \
 		export DATABASE_URL="$(DATABASE_URL)" && go run . & \
 		APP_PID=$$!; \
-		sleep 5; \
-		echo "🔍 Testing health endpoint..."; \
-		curl -f http://localhost:8080/api/health || (echo "❌ Health check failed" && kill $$APP_PID && exit 1); \
-		echo ""; \
-		echo "🔍 Testing user endpoints (generated repositories)..."; \
-		curl -f http://localhost:8080/api/users || (echo "❌ Users endpoint failed" && kill $$APP_PID && exit 1); \
-		echo "✅ Users endpoint working"; \
-		echo "🔍 Testing post endpoints (custom repositories)..."; \
-		curl -f http://localhost:8080/api/posts || (echo "❌ Posts endpoint failed" && kill $$APP_PID && exit 1); \
-		echo "✅ Posts endpoint working"; \
-		echo "🔍 Testing posts with stats (generated query integration)..."; \
-		curl -f http://localhost:8080/api/posts/with-stats || (echo "❌ Posts with stats failed" && kill $$APP_PID && exit 1); \
-		echo "✅ Posts with stats working"; \
-		echo "🔍 Testing featured posts (custom business logic)..."; \
-		curl -f http://localhost:8080/api/posts/featured || (echo "❌ Featured posts failed" && kill $$APP_PID && exit 1); \
-		echo "✅ Featured posts working"; \
-		echo "🔍 Testing post statistics (aggregation)..."; \
-		curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/api/posts/statistics | grep -E "^(200|500)$$" > /dev/null || (echo "❌ Post statistics unexpected response" && kill $$APP_PID && exit 1); \
-		echo "✅ Post statistics endpoint accessible (may return 500 due to unimplemented aggregation - expected)"; \
-		echo "🔍 Testing user search (query-based functionality)..."; \
-		curl -f "http://localhost:8080/api/users/search?q=test" || (echo "❌ User search failed" && kill $$APP_PID && exit 1); \
-		echo "✅ User search working"; \
-		echo "🔍 Validating API returns actual data (not stub responses)..."; \
-		RESPONSE=$$(curl -s http://localhost:8080/api/posts); \
-		if echo "$$RESPONSE" | grep -q "not implemented"; then \
-			echo "❌ API still returning stub responses"; \
-			kill $$APP_PID; \
-			exit 1; \
-		fi; \
-		echo "✅ API returning real data from generated repositories"; \
-		echo "🛑 Stopping application..."; \
+		sleep 4; \
+		echo "Testing endpoints..."; \
+		curl -f http://localhost:8080/api/health || (kill $$APP_PID 2>/dev/null; exit 1); \
+		curl -f http://localhost:8080/api/users || (kill $$APP_PID 2>/dev/null; exit 1); \
+		curl -f http://localhost:8080/api/posts || (kill $$APP_PID 2>/dev/null; exit 1); \
+		curl -f http://localhost:8080/api/posts/with-stats || (kill $$APP_PID 2>/dev/null; exit 1); \
+		curl -f http://localhost:8080/api/posts/featured || (kill $$APP_PID 2>/dev/null; exit 1); \
+		curl -f "http://localhost:8080/api/users/search?q=test" || (kill $$APP_PID 2>/dev/null; exit 1); \
 		kill $$APP_PID 2>/dev/null || true; \
 		wait $$APP_PID 2>/dev/null || true; \
-	else \
-		echo "⚠️  curl not available - skipping HTTP tests (compilation test passed)"; \
 	fi
-	@echo "✅ Application integration tests passed - all generated code working correctly"
+	@echo "✅ Tests passed"
 
-run: ## Run the application
-	@echo "🚀 Starting server..."
+run:
 	@export DATABASE_URL="$(DATABASE_URL)" && go run .
 
-migrate-up: install-migrate ## Apply all pending migrations
-	@echo "⬆️  Applying migrations..."
+migrate-up: install-migrate
 	@migrate -database "$(DATABASE_URL)" -path database/migrations up
-	@echo "✅ Migrations applied"
 
-migrate-down: install-migrate ## Rollback one migration
-	@echo "⬇️  Rolling back one migration..."
+migrate-down: install-migrate
 	@migrate -database "$(DATABASE_URL)" -path database/migrations down 1
-	@echo "✅ Rollback complete"
 
-migrate-status: install-migrate ## Show migration status
-	@echo "📊 Migration status:"
+migrate-status: install-migrate
 	@migrate -database "$(DATABASE_URL)" -path database/migrations version
 
-migrate-create: install-migrate ## Create a new migration (usage: make migrate-create NAME=add_new_table)
-	@if [ -z "$(NAME)" ]; then \
-		echo "❌ Please provide a migration name: make migrate-create NAME=your_migration_name"; \
-		exit 1; \
-	fi
-	@echo "🆕 Creating migration: $(NAME)"
+migrate-create: install-migrate
+	@if [ -z "$(NAME)" ]; then echo "Usage: make migrate-create NAME=<name>"; exit 1; fi
 	@migrate create -ext sql -dir database/migrations -seq $(NAME)
-	@echo "✅ Migration files created"
 
-clean: ## Clean up
-	@echo "🧹 Cleaning..."
+clean:
 	@rm -rf repository/generated/
 	@docker stop blog-db 2>/dev/null || true
 	@docker rm blog-db 2>/dev/null || true
-	@echo "✅ Clean" 
+	@echo "✅ Clean"


### PR DESCRIPTION
Closes #87

Simplify test targets with consistent naming that auto-handles prerequisites:

- `make test-unit` - unit tests (no database needed)
- `make test-integration` - integration tests (auto-starts database)
- `make test-example-app` - example-app tests (auto-setup + generate + test)
- `make test-all` - runs all three

Removes need for manual `make dev-setup` or `make setup` steps.