### PR TITLE
fix: accept []byte, json.RawMessage and other valid Go types in annotations

### DIFF
--- a/internal/generator/query_parser.go
+++ b/internal/generator/query_parser.go
@@ -318,7 +318,8 @@ func isValidGoIdentifier(name string) bool {
 // Expected format: -- param: $N parameter_name go_type
 func (qp *QueryParser) parseParameterAnnotation(line string) *ParameterAnnotation {
 	// Regex to match: -- param: $N parameter_name go_type
-	paramRegex := regexp.MustCompile(`^--\s*param:\s*\$(\d+)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+(\*?[a-zA-Z_][a-zA-Z0-9_.]*)\s*$`)
+	// Type pattern allows: pointers (*), slices ([]), maps (map[]), and qualified names (pkg.Type)
+	paramRegex := regexp.MustCompile(`^--\s*param:\s*\$(\d+)\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+(.+?)\s*$`)
 
 	matches := paramRegex.FindStringSubmatch(line)
 	if len(matches) != 4 {
@@ -345,7 +346,8 @@ func (qp *QueryParser) parseParameterAnnotation(line string) *ParameterAnnotatio
 // Expected format: -- result: column_name go_type
 func (qp *QueryParser) parseResultAnnotation(line string) *ResultAnnotation {
 	// Regex to match: -- result: column_name go_type
-	resultRegex := regexp.MustCompile(`^--\s*result:\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+(\*?[a-zA-Z_][a-zA-Z0-9_.]*)\s*$`)
+	// Type pattern allows: pointers (*), slices ([]), maps (map[]), and qualified names (pkg.Type)
+	resultRegex := regexp.MustCompile(`^--\s*result:\s+([a-zA-Z_][a-zA-Z0-9_]*)\s+(.+?)\s*$`)
 
 	matches := resultRegex.FindStringSubmatch(line)
 	if len(matches) != 3 {
@@ -465,23 +467,22 @@ func isValidColumnName(name string) bool {
 }
 
 // isValidGoType performs basic validation of Go type syntax
+// This is intentionally permissive - the Go compiler will catch actual type errors
 func isValidGoType(goType string) bool {
 	if goType == "" {
 		return false
 	}
 
-	// Handle pointer types
-	goType = strings.TrimPrefix(goType, "*")
-
-	// Must be a valid Go identifier or qualified identifier (e.g., uuid.UUID, time.Time)
-	parts := strings.Split(goType, ".")
-	for _, part := range parts {
-		if !isValidGoIdentifier(part) {
-			return false
+	// Basic sanity check: must contain at least one letter
+	hasLetter := false
+	for _, r := range goType {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+			hasLetter = true
+			break
 		}
 	}
 
-	return len(parts) <= 2
+	return hasLetter
 }
 
 // parseCursorColumnsAnnotation parses a cursor_columns annotation

--- a/internal/generator/query_parser_test.go
+++ b/internal/generator/query_parser_test.go
@@ -445,32 +445,6 @@ func TestQueryParser_ValidateResultAnnotations(t *testing.T) {
 			errorMsg: "duplicate result annotation",
 		},
 		{
-			name: "invalid Go type",
-			query: Query{
-				Name: "GetUser",
-				Type: QueryTypeOne,
-				SQL:  "SELECT id FROM users",
-				ResultAnnotations: []ResultAnnotation{
-					{ColumnName: "payment_count", GoType: "invalid type"},
-				},
-			},
-			hasError: true,
-			errorMsg: "invalid Go type",
-		},
-		{
-			name: "invalid Go type with special chars",
-			query: Query{
-				Name: "GetUser",
-				Type: QueryTypeOne,
-				SQL:  "SELECT id FROM users",
-				ResultAnnotations: []ResultAnnotation{
-					{ColumnName: "payment_count", GoType: "int@invalid"},
-				},
-			},
-			hasError: true,
-			errorMsg: "invalid Go type",
-		},
-		{
 			name: "empty result annotations",
 			query: Query{
 				Name:              "GetUser",
@@ -524,13 +498,14 @@ func TestQueryParser_IsValidGoType(t *testing.T) {
 		{"string type", "string", true},
 		{"custom type", "MyCustomType", true},
 		{"qualified custom type", "pkg.MyType", true},
+		{"slice of bytes", "[]byte", true},
+		{"pointer to slice", "*[]byte", true},
+		{"json.RawMessage", "json.RawMessage", true},
+		{"pointer json.RawMessage", "*json.RawMessage", true},
+		{"slice of strings", "[]string", true},
+		{"map type", "map[string]any", true},
+		{"deeply qualified", "pkg.sub.Type", true},
 		{"empty string", "", false},
-		{"invalid with space", "int 64", false},
-		{"invalid with special char", "int@type", false},
-		{"too many dots", "pkg.sub.Type", false},
-		{"starts with number", "123Type", false},
-		{"invalid qualified", ".Type", false},
-		{"invalid qualified end", "pkg.", false},
 	}
 
 	for _, tt := range tests {
@@ -672,14 +647,6 @@ func TestQueryParser_ValidateParameterAnnotations(t *testing.T) {
 			},
 			shouldError: true,
 			errorMsg:    "parameter annotations must be sequential starting at $1, missing $2",
-		},
-		{
-			name: "invalid Go type",
-			annotations: []ParameterAnnotation{
-				{Position: 1, Name: "tenant_id", GoType: "invalid type"},
-			},
-			shouldError: true,
-			errorMsg:    "invalid Go type",
 		},
 	}
 


### PR DESCRIPTION
## Summary
- Make type validation permissive for `--param:` and `--result:` annotations
- Relaxes regex patterns to accept any Go type expression (slices, maps, qualified types)
- Simplifies `isValidGoType()` to only check for presence of letters
- The Go compiler catches actual type errors during build

## Test plan
- [x] Unit tests pass (`make test-unit`)
- [x] Example app tests pass (`make test-example-app`)
- [x] Linting passes (`make lint`)

Fixes #95