### PR TITLE
fix: add type mapping support for SERIAL, BIGSERIAL, SMALLSERIAL

### DIFF
--- a/docs/type-mapping.md
+++ b/docs/type-mapping.md
@@ -4,7 +4,7 @@ Skimatik uses intelligent, idiomatic Go type mappings that prioritize ergonomics
 
 ## Design Philosophy
 
-- **All integers map to `int`** - Whether your column is `SMALLINT`, `INTEGER`, or `BIGINT`, it maps to Go's native `int`
+- **All integers map to `int`** - Whether your column is `SMALLINT`, `INTEGER`, `BIGINT`, `SERIAL`, `BIGSERIAL`, or `SMALLSERIAL`, it maps to Go's native `int`
 - **NOT NULL columns use native Go types** - Direct types like `int`, `string`, `uuid.UUID`, `time.Time`
 - **Nullable columns use pointers** - NULL support via `*int`, `*string`, `*uuid.UUID`, `*time.Time`
 - **No dependencies on pgtype** - Pure Go types only
@@ -13,9 +13,9 @@ Skimatik uses intelligent, idiomatic Go type mappings that prioritize ergonomics
 
 | PostgreSQL Type | NOT NULL Go Type | NULLABLE Go Type |
 |----------------|------------------|------------------|
-| `SMALLINT`, `INT2` | `int` | `*int` |
-| `INTEGER`, `INT`, `INT4` | `int` | `*int` |
-| `BIGINT`, `INT8` | `int` | `*int` |
+| `SMALLINT`, `INT2`, `SMALLSERIAL` | `int` | `*int` |
+| `INTEGER`, `INT`, `INT4`, `SERIAL` | `int` | `*int` |
+| `BIGINT`, `INT8`, `BIGSERIAL` | `int` | `*int` |
 | `TEXT`, `VARCHAR` | `string` | `*string` |
 | `BOOLEAN`, `BOOL` | `bool` | `*bool` |
 | `UUID` | `uuid.UUID` | `*uuid.UUID` |

--- a/internal/generator/types_mapping.go
+++ b/internal/generator/types_mapping.go
@@ -54,7 +54,7 @@ func (tm *TypeMapper) getBaseGoType(pgType string) (string, error) {
 		return "string", nil
 
 	// Integer types - all map to int for ergonomic, idiomatic Go
-	case "smallint", "int2", "integer", "int", "int4", "bigint", "int8":
+	case "smallint", "int2", "integer", "int", "int4", "bigint", "int8", "serial", "bigserial", "smallserial":
 		return "int", nil
 
 	// Floating point types


### PR DESCRIPTION
## Summary
- Add `serial`, `bigserial`, `smallserial` to integer type mappings
- Update type-mapping documentation to include SERIAL types

Closes #96