### PR TITLE
chore: update CI to use Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.24', '1.25' ]
+        go-version: [ '1.25', '1.26' ]
 
     steps:
     - uses: actions/checkout@v6
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
@@ -67,7 +67,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Install Gosec
       run: go install github.com/securego/gosec/v2/cmd/gosec@latest
@@ -86,7 +86,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Build
       run: go build -v ./...
@@ -102,7 +102,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Start database
       run: docker compose -f build/docker-compose.yml up -d postgres
@@ -131,7 +131,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -139,9 +139,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.24-example-app-${{ hashFiles('**/go.sum') }}-v1
+        key: ${{ runner.os }}-go-1.25-example-app-${{ hashFiles('**/go.sum') }}-v1
         restore-keys: |
-          ${{ runner.os }}-go-1.24-example-app-v1-
+          ${{ runner.os }}-go-1.25-example-app-v1-
 
     - name: Download dependencies
       run: go mod download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,10 +29,10 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.25'
 
     - name: Run GoReleaser
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@v7
       with:
         distribution: goreleaser
         version: "~> v2"


### PR DESCRIPTION
Updates all CI jobs to use Go 1.25, which is required for the open dependabot PRs (#118, #120, #121) that bump go.mod to 1.25.0.

Changes:
- Test matrix: [1.24, 1.25] → [1.25, 1.26]
- All hardcoded `go-version: '1.24'` in CI → '1.25'
- goreleaser-action v6 → v7 in release.yml

Once this merges, the dependabot PRs can be re-created and will pass CI.