### PR TITLE
fix(security): address gosec findings

### DIFF
--- a/internal/generator/codegen.go
+++ b/internal/generator/codegen.go
@@ -558,7 +558,7 @@ func (cg *CodeGenerator) writeCodeToFile(filename, code string) error {
 	}
 
 	// Write to file
-	if err := os.WriteFile(filename, formatted, 0644); err != nil {
+	if err := os.WriteFile(filename, formatted, 0644); err != nil { // #nosec G306 -- generated source is intentionally world-readable for editors/CI/containers
 		return fmt.Errorf("failed to write file %s: %w", filename, err)
 	}
 

--- a/internal/generator/config.go
+++ b/internal/generator/config.go
@@ -111,7 +111,7 @@ func parseDefaultFunctions(value interface{}) ([]string, error) {
 
 // LoadConfig loads configuration from a YAML file
 func LoadConfig(path string) (*Config, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) // #nosec G304 -- user-supplied config path by design
 	if err != nil {
 		return nil, fmt.Errorf("failed to read config file: %w", err)
 	}
@@ -184,7 +184,7 @@ func (c *Config) Validate() error {
 	}
 
 	// Ensure output directory exists or can be created
-	if err := os.MkdirAll(c.OutputDir, 0755); err != nil {
+	if err := os.MkdirAll(c.OutputDir, 0750); err != nil {
 		return fmt.Errorf("failed to create output directory: %w", err)
 	}
 

--- a/internal/generator/query_parser.go
+++ b/internal/generator/query_parser.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 )
 
@@ -74,7 +75,7 @@ func (qp *QueryParser) findSQLFiles() ([]string, error) {
 
 // parseFile parses a single SQL file and extracts queries with annotations
 func (qp *QueryParser) parseFile(filename string) ([]Query, error) {
-	file, err := os.Open(filename)
+	file, err := os.Open(filename) // #nosec G304 -- user-supplied query file path by design
 	if err != nil {
 		return nil, fmt.Errorf("failed to open file: %w", err)
 	}
@@ -307,8 +308,10 @@ func (qp *QueryParser) parseParameterAnnotation(line string) *ParameterAnnotatio
 		return nil
 	}
 
-	position := 0
-	fmt.Sscanf(matches[1], "%d", &position)
+	position, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return nil
+	}
 	paramName := strings.TrimSpace(matches[2])
 	goType := strings.TrimSpace(matches[3])
 


### PR DESCRIPTION
## Summary

Resolves the five pre-existing gosec findings that show as a red annotation on every successful CI run (CI runs `gosec -exclude=G115 ./...` with `continue-on-error: true`).

- **G104** `internal/generator/query_parser.go`: replace `fmt.Sscanf` with `strconv.Atoi` and propagate failure as `return nil` to match the existing malformed-annotation handling. Regex `\d+` already guarantees parse success, so this is a structural no-op.
- **G301** `internal/generator/config.go`: tighten `MkdirAll` mode from `0755` to `0750` on the generated-code output dir; world-list isn't needed.
- **G304** `internal/generator/query_parser.go` + `internal/generator/config.go`: suppress with `#nosec G304` and a justification — both read user-supplied paths by design.
- **G306** `internal/generator/codegen.go`: suppress with `#nosec G306` and a justification — generated Go source is intentionally world-readable so editors / CI / containers running as other users can read it.

## Test plan

- [x] `make test-unit` passes locally
- [x] `make lint` passes locally (`✅ Linting completed`)
- [ ] `gosec -exclude=G115 ./...` clean (gosec not on local PATH; CI will validate)

Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)