### PR TITLE
fix(hooks): clean up postgres container after pre-push integration tests (#142)

### DIFF
--- a/lefthook.yml
+++ b/lefthook.yml
@@ -27,4 +27,9 @@ commit-msg:
 pre-push:
   jobs:
     - name: integration
-      run: make test-integration
+      # Tear down the postgres container on exit so the host port (15432) is
+      # released for sibling projects that bind the same port. The trap fires
+      # on success and failure alike — see #142.
+      run: |
+        trap 'docker compose -f build/docker-compose.yml down -v --remove-orphans >/dev/null 2>&1 || true' EXIT
+        make test-integration


### PR DESCRIPTION
## Summary

The pre-push lefthook job ran \`make test-integration\` which started the postgres container on port 15432 but never stopped it. The container stayed bound after each push, blocking sibling projects that use the same port (\`dwconnector_test_db\` in particular).

Wrap the hook's \`make test-integration\` call in a trap that runs \`docker compose -f build/docker-compose.yml down -v --remove-orphans\` on exit. The trap fires on success and failure alike, so the port is released regardless of whether the tests passed.

The \`make test-integration\` Makefile target itself is unchanged — running it interactively still leaves the DB up for follow-up debugging. The cleanup is scoped to the pre-push hook because that's where the unattended, port-blocking behavior shows up.

Closes #142.

## Test plan

- [x] Push this branch with the new hook in place. Confirm pre-push runs, integration tests pass, and \`docker ps\` shows no \`skimatik-postgres\` container after the push completes.
- [x] Confirm a sibling container that uses port 15432 (\`dwconnector_test_db\`) can start cleanly afterwards without manually stopping anything.
- [ ] CI still green (CI doesn't run lefthook hooks, but exercising the same Makefile target).

🤖 Generated with [Claude Code](https://claude.com/claude-code)