### PR TITLE
chore: bump module Go version to 1.25

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ func (q *Queries) ListUsersWithFilters(
 
 ## Requirements
 
-- Go 1.24+
+- Go 1.25+
 - PostgreSQL (any version supported by pgx)
 - Tables must have single-column primary keys (composite keys not supported)
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -15,7 +15,7 @@ make setup && make generate && make run
 
 ## Prerequisites
 
-- **Go 1.24+** - Required for installation and generated code
+- **Go 1.25+** - Required for installation and generated code
 - **PostgreSQL** - Any version supported by pgx
 - **Database with UUID v7 primary keys** - Required for pagination support
 

--- a/example-app/go.mod
+++ b/example-app/go.mod
@@ -1,8 +1,6 @@
 module github.com/nhalm/skimatik/v2/example-app
 
-go 1.24.0
-
-toolchain go1.24.5
+go 1.25.0
 
 require (
 	github.com/go-chi/chi/v5 v5.0.12

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/nhalm/skimatik/v2
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/google/uuid v1.6.0


### PR DESCRIPTION
## Summary

- Bump `go.mod` (root) and `example-app/go.mod` from `go 1.24.0` to `go 1.25.0`.
- Drop the `toolchain go1.24.5` directive from `example-app/go.mod` in favor of a single `go` line, matching go-blueprint.
- Update README and quick-start docs from "Go 1.24+" to "Go 1.25+".

CI already runs the `1.25` / `1.26` matrix, so no workflow changes are needed — this just brings the declared module version in line with what we already build and test against, and unblocks dependencies that require Go 1.25 (e.g. `pgxkit/v2 v2.1.0`).

Closes #148

## Test plan

- [x] `make build` succeeds on local Go 1.26 toolchain
- [x] `make lint` clean (root + example-app)
- [x] `make test-unit` passes
- [x] `make test-integration` passes
- [x] `make test-example-app` passes (build, generate, integration, generated-code lint)
- [ ] CI green on the 1.25/1.26 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)