### PR TITLE
fix: replace deprecated archives.format with formats list

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -25,7 +25,7 @@ builds:
       - -X main.date={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats: [tar.gz]
     name_template: >-
       {{ .ProjectName }}_
       {{- .Version }}_
@@ -36,7 +36,7 @@ archives:
       {{- if .Arm }}v{{ .Arm }}{{ end }}
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
     files:
       - LICENSE
       - README.md


### PR DESCRIPTION
## Summary
- Replace deprecated `archives.format` / `format_overrides.format` (singular) with the plural list form (`formats: [...]`) in `.goreleaser.yml`.
- `goreleaser check` now reports no deprecations.

Closes #154

## Test plan
- [x] `goreleaser check` passes locally with no DEPRECATED warnings
- [ ] Next tagged release runs without GoReleaser deprecation output

🤖 Generated with [Claude Code](https://claude.com/claude-code)