### PR TITLE
fix: include columns with DEFAULT in Create<Table>Params

### DIFF
--- a/example-app/internal/repository/golden_test.go
+++ b/example-app/internal/repository/golden_test.go
@@ -81,9 +81,13 @@ func TestUsersRepository_Golden(t *testing.T) {
 	repo := generated.NewUsersRepository(fixedIDGen())
 	ctx := context.Background()
 
+	now := time.Now()
 	created, err := repo.Create(ctx, golden, generated.CreateUsersParams{
-		Name:  "Golden Test User",
-		Email: "golden-test@example.com",
+		Name:      "Golden Test User",
+		Email:     "golden-test@example.com",
+		IsActive:  true,
+		CreatedAt: now,
+		UpdatedAt: now,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)
@@ -105,9 +109,13 @@ func TestUsersRepository_Plan(t *testing.T) {
 	repo := generated.NewUsersRepository(fixedIDGen())
 	ctx := context.Background()
 
+	now := time.Now()
 	created, err := repo.Create(ctx, plan, generated.CreateUsersParams{
-		Name:  "Plan Test User",
-		Email: "plan-test@example.com",
+		Name:      "Plan Test User",
+		Email:     "plan-test@example.com",
+		IsActive:  true,
+		CreatedAt: now,
+		UpdatedAt: now,
 	})
 	if err != nil {
 		t.Fatalf("Create: %v", err)

--- a/example-app/internal/repository/testdata/golden/TestUsersRepository_Golden.json
+++ b/example-app/internal/repository/testdata/golden/TestUsersRepository_Golden.json
@@ -2,12 +2,15 @@
   {
     "step": 1,
     "event": "QUERY",
-    "sql": "\n\t\tWITH inserted AS (\n\t\t\tINSERT INTO users (id, name, email, bio, deleted_at)\n\t\t\tVALUES ($1, $2, $3, $4, $5)\n\t\t\tRETURNING id, name, email, bio, is_active, created_at, updated_at, deleted_at\n\t\t),\n\t\taudited AS (\n\t\t\tINSERT INTO users_audit (id, parent_id, version, snapshot, valid_from)\n\t\t\tSELECT $6, id, 1, to_jsonb(inserted.*), NOW() FROM inserted\n\t\t)\n\t\tSELECT id, name, email, bio, is_active, created_at, updated_at, deleted_at FROM inserted\n\t",
+    "sql": "\n\t\tWITH inserted AS (\n\t\t\tINSERT INTO users (id, name, email, bio, is_active, created_at, updated_at, deleted_at)\n\t\t\tVALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n\t\t\tRETURNING id, name, email, bio, is_active, created_at, updated_at, deleted_at\n\t\t),\n\t\taudited AS (\n\t\t\tINSERT INTO users_audit (id, parent_id, version, snapshot, valid_from)\n\t\t\tSELECT $9, id, 1, to_jsonb(inserted.*), NOW() FROM inserted\n\t\t)\n\t\tSELECT id, name, email, bio, is_active, created_at, updated_at, deleted_at FROM inserted\n\t",
     "args": [
       "\u003cUUID:1\u003e",
       "Golden Test User",
       "golden-test@example.com",
       null,
+      true,
+      "\u003cTIMESTAMP\u003e",
+      "\u003cTIMESTAMP\u003e",
       null,
       "\u003cUUID:2\u003e"
     ]

--- a/example-app/internal/repository/testdata/plans/TestUsersRepository_Plan.json
+++ b/example-app/internal/repository/testdata/plans/TestUsersRepository_Plan.json
@@ -1,7 +1,7 @@
 [
   {
     "query": 1,
-    "sql": "\n\t\tWITH inserted AS (\n\t\t\tINSERT INTO users (id, name, email, bio, deleted_at)\n\t\t\tVALUES ($1, $2, $3, $4, $5)\n\t\t\tRETURNING id, name, email, bio, is_active, created_at, updated_at, deleted_at\n\t\t),\n\t\taudited AS (\n\t\t\tINSERT INTO users_audit (id, parent_id, version, snapshot, valid_from)\n\t\t\tSELECT $6, id, 1, to_jsonb(inserted.*), NOW() FROM inserted\n\t\t)\n\t\tSELECT id, name, email, bio, is_active, created_at, updated_at, deleted_at FROM inserted\n\t",
+    "sql": "\n\t\tWITH inserted AS (\n\t\t\tINSERT INTO users (id, name, email, bio, is_active, created_at, updated_at, deleted_at)\n\t\t\tVALUES ($1, $2, $3, $4, $5, $6, $7, $8)\n\t\t\tRETURNING id, name, email, bio, is_active, created_at, updated_at, deleted_at\n\t\t),\n\t\taudited AS (\n\t\t\tINSERT INTO users_audit (id, parent_id, version, snapshot, valid_from)\n\t\t\tSELECT $9, id, 1, to_jsonb(inserted.*), NOW() FROM inserted\n\t\t)\n\t\tSELECT id, name, email, bio, is_active, created_at, updated_at, deleted_at FROM inserted\n\t",
     "plan": [
       {
         "Plan": {

--- a/example-app/internal/repository/user_repository.go
+++ b/example-app/internal/repository/user_repository.go
@@ -117,10 +117,15 @@ func (r *UserRepository) GetUser(ctx context.Context, userID uuid.UUID) (*models
 
 // CreateUser delegates to the audited generated Create.
 func (r *UserRepository) CreateUser(ctx context.Context, name, email string, bio *string) (*models.UserSummary, error) {
+	now := time.Now()
 	user, err := r.Create(ctx, executorFromContext(ctx, r.db), generated.CreateUsersParams{
-		Name:  name,
-		Email: email,
-		Bio:   bio,
+		Name:      name,
+		Email:     email,
+		Bio:       bio,
+		IsActive:  true,
+		CreatedAt: now,
+		UpdatedAt: now,
+		DeletedAt: nil,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("failed to create user: %w", err)

--- a/internal/generator/audit_runtime_integration_test.go
+++ b/internal/generator/audit_runtime_integration_test.go
@@ -204,8 +204,8 @@ func TestAuditCTE_CreateAndUpdate(t *testing.T) {
 }
 
 // buildCreateArgs returns positional args matching prepareCRUDTemplateData's
-// layout for audited CREATE: id, then every non-id column whose DefaultValue
-// is empty, in declaration order, then the audit row id appended last.
+// layout for audited CREATE: id, then every non-id column in declaration
+// order, then the audit row id appended last.
 //
 // NOTE: this helper reimplements prepareCRUDTemplateData's positional-arg
 // ordering. If templates ever reorder columns, this helper silently binds
@@ -216,7 +216,7 @@ func buildCreateArgs(t *testing.T, table table, id uuid.UUID, name, email, passw
 	t.Helper()
 	args := []any{id}
 	for _, col := range table.Columns {
-		if col.Name == "id" || col.DefaultValue != "" {
+		if col.Name == "id" {
 			continue
 		}
 		switch col.Name {
@@ -228,7 +228,7 @@ func buildCreateArgs(t *testing.T, table table, id uuid.UUID, name, email, passw
 			args = append(args, passwordHash)
 		default:
 			if !col.IsNullable {
-				t.Fatalf("buildCreateArgs has no value for NOT NULL column %q without default; users fixture changed?", col.Name)
+				t.Fatalf("buildCreateArgs has no value for NOT NULL column %q; users fixture changed?", col.Name)
 			}
 			args = append(args, nil)
 		}

--- a/internal/generator/codegen.go
+++ b/internal/generator/codegen.go
@@ -389,18 +389,16 @@ func (cg *CodeGenerator) prepareCRUDTemplateData(table table) map[string]any {
 			continue
 		}
 
-		if col.DefaultValue == "" {
-			createFields = append(createFields, map[string]string{
-				"Name": col.goFieldName(),
-				"Type": col.GoType,
-				"Tag":  col.goStructTag(),
-			})
+		createFields = append(createFields, map[string]string{
+			"Name": col.goFieldName(),
+			"Type": col.GoType,
+			"Tag":  col.goStructTag(),
+		})
 
-			insertColumns = append(insertColumns, col.Name)
-			insertPlaceholders = append(insertPlaceholders, fmt.Sprintf("$%d", createParamIndex))
-			insertArgs = append(insertArgs, "params."+col.goFieldName())
-			createParamIndex++
-		}
+		insertColumns = append(insertColumns, col.Name)
+		insertPlaceholders = append(insertPlaceholders, fmt.Sprintf("$%d", createParamIndex))
+		insertArgs = append(insertArgs, "params."+col.goFieldName())
+		createParamIndex++
 
 		updateFields = append(updateFields, map[string]string{
 			"Name": col.goFieldName(),

--- a/internal/generator/codegen_test.go
+++ b/internal/generator/codegen_test.go
@@ -51,10 +51,10 @@ func TestCodeGenerator_prepareCRUDTemplateData(t *testing.T) {
 		}
 	}
 
-	// Check create fields (should exclude ID and columns with defaults)
+	// Check create fields (should include all non-ID columns, mirroring update)
 	createFields := data["CreateFields"].([]map[string]string)
-	if len(createFields) != 3 { // name, email, metadata
-		t.Errorf("Expected 3 create fields, got %d", len(createFields))
+	if len(createFields) != 5 { // name, email, is_active, created_at, metadata
+		t.Errorf("Expected 5 create fields, got %d", len(createFields))
 	}
 
 	// Check update fields (should include all non-ID columns)

--- a/internal/generator/testdata/golden/TestAuditCTE_Golden.json
+++ b/internal/generator/testdata/golden/TestAuditCTE_Golden.json
@@ -2,12 +2,15 @@
   {
     "step": 1,
     "event": "QUERY",
-    "sql": "\n\t\tWITH inserted AS (\n\t\t\tINSERT INTO users (id, name, email, password_hash, last_login, metadata, age, balance, profile_picture_url)\n\t\t\tVALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)\n\t\t\tRETURNING id, name, email, password_hash, is_active, created_at, updated_at, last_login, metadata, age, balance, profile_picture_url\n\t\t),\n\t\taudited AS (\n\t\t\tINSERT INTO users_audit (id, parent_id, version, snapshot, valid_from)\n\t\t\tSELECT $10, id, 1, to_jsonb(inserted.*), NOW() FROM inserted\n\t\t)\n\t\tSELECT id, name, email, password_hash, is_active, created_at, updated_at, last_login, metadata, age, balance, profile_picture_url FROM inserted\n\t",
+    "sql": "\n\t\tWITH inserted AS (\n\t\t\tINSERT INTO users (id, name, email, password_hash, is_active, created_at, updated_at, last_login, metadata, age, balance, profile_picture_url)\n\t\t\tVALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)\n\t\t\tRETURNING id, name, email, password_hash, is_active, created_at, updated_at, last_login, metadata, age, balance, profile_picture_url\n\t\t),\n\t\taudited AS (\n\t\t\tINSERT INTO users_audit (id, parent_id, version, snapshot, valid_from)\n\t\t\tSELECT $13, id, 1, to_jsonb(inserted.*), NOW() FROM inserted\n\t\t)\n\t\tSELECT id, name, email, password_hash, is_active, created_at, updated_at, last_login, metadata, age, balance, profile_picture_url FROM inserted\n\t",
     "args": [
       "\u003cUUID:1\u003e",
       "Audit Test User",
       "audit-cte-golden-create@example.com",
       "hash-placeholder",
+      null,
+      null,
+      null,
       null,
       null,
       null,


### PR DESCRIPTION
## Summary
- Removes the `if col.DefaultValue == ""` guard in `prepareCRUDTemplateData` (`internal/generator/codegen.go`) so generated `Create<Table>Params` includes every non-id column, mirroring `Update<Table>Params`. Resolves the asymmetry that forced callers into a non-atomic "Create then Update" pattern when they needed to set a column with a `DEFAULT` clause (e.g. `tags JSONB NOT NULL DEFAULT '[]'::jsonb`).
- Updates the affected tests/fixtures: `codegen_test.go` expectation, `audit_runtime_integration_test.go` `buildCreateArgs` filter, audit golden snapshot, and the example-app `CreateUser` caller plus its golden + plan baselines.

## Breaking change
Callers that previously relied on DB-side defaults (`created_at`, `updated_at`, `is_active`, etc.) must now pass values explicitly. Passing zero values inserts NULL or epoch timestamps rather than triggering the column default. The example-app's `CreateUser` was updated to pass `time.Now()`/`true` accordingly.

## Test plan
- [x] `make test-unit` passes (incl. `TestCodeGenerator_prepareCRUDTemplateData` with the new 5-field expectation)
- [x] `make lint` reports `0 issues` from golangci-lint
- [ ] `make test-integration` (requires Postgres) — `TestAuditCTE_Golden` should match the regenerated baseline
- [ ] `make test-example-app` (requires Postgres) — `TestUsersRepository_Golden` and `TestUsersRepository_Plan` should match the regenerated baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)